### PR TITLE
Add a system tray feature to lofi-in-your-desktop

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1369,10 +1369,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "libappindicator"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2d3cb96d092b4824cb306c9e544c856a4cb6210c1081945187f7f1924b47e8"
+dependencies = [
+ "glib",
+ "gtk",
+ "gtk-sys",
+ "libappindicator-sys",
+ "log",
+]
+
+[[package]]
+name = "libappindicator-sys"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b3b6681973cea8cc3bce7391e6d7d5502720b80a581c9a95c9cbaf592826aa"
+dependencies = [
+ "gtk-sys",
+ "libloading",
+ "once_cell",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "line-wrap"
@@ -2476,6 +2510,7 @@ dependencies = [
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
+ "dirs-next",
  "dispatch",
  "gdk",
  "gdk-pixbuf",
@@ -2490,6 +2525,7 @@ dependencies = [
  "instant",
  "jni",
  "lazy_static",
+ "libappindicator",
  "libc",
  "log",
  "ndk",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "1.4", features = [] }
 
 [dependencies]
-tauri = { version = "1.4", features = ["shell-open", "window-close", "window-hide", "window-maximize", "window-minimize", "window-show", "window-start-dragging", "window-unmaximize", "window-unminimize"] }
+tauri = { version = "1.4", features = [ "system-tray", "shell-open", "window-close", "window-hide", "window-maximize", "window-minimize", "window-show", "window-start-dragging", "window-unmaximize", "window-unminimize"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 window-shadows = "0.2.1"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,8 +3,11 @@
   windows_subsystem = "windows"
 )]
 
-use tauri::Manager;
+use sys_tray::build_tray;
+use tauri::{Manager, SystemTrayEvent};
 use window_shadows::set_shadow;
+
+mod sys_tray;
 
 fn main() {
   tauri::Builder::default()
@@ -12,6 +15,31 @@ fn main() {
       let window = app.get_window("main").unwrap();
       set_shadow(&window, true).expect("Unsupported platform!");
       Ok(())
+    })
+    .system_tray(build_tray())
+    .on_system_tray_event(
+    |app, event| match event {
+      SystemTrayEvent::DoubleClick {
+        position: _,
+        size: _,
+        ..
+      } => {
+        app.get_window("main").unwrap().show().unwrap();
+      },
+      SystemTrayEvent::MenuItemClick { id, .. } => {
+        match id.as_str() {
+          "hide" => {
+            let window = app.get_window("main").unwrap();
+            window.hide().unwrap();
+          }
+          "quit" => {
+            let window = app.get_window("main").unwrap();
+            window.close().unwrap();
+          }
+          _ => {}
+        }
+      }
+      _ => {}
     })
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,6 +14,7 @@ fn main() {
     .setup(|app| {
       let window = app.get_window("main").unwrap();
       set_shadow(&window, true).expect("Unsupported platform!");
+      window.hide().unwrap();
       Ok(())
     })
     .system_tray(build_tray())

--- a/src-tauri/src/sys_tray.rs
+++ b/src-tauri/src/sys_tray.rs
@@ -1,0 +1,13 @@
+use tauri::{CustomMenuItem, SystemTrayMenu, SystemTrayMenuItem,SystemTray};
+
+pub fn build_tray() -> SystemTray {
+    // here `"quit".to_string()` defines the menu item id, and the second parameter is the menu item label.
+    let quit = CustomMenuItem::new("quit".to_string(), "Quit");
+    let hide = CustomMenuItem::new("hide".to_string(), "Hide");
+    let tray_menu = SystemTrayMenu::new()
+    .add_item(quit)
+    .add_native_item(SystemTrayMenuItem::Separator)
+    .add_item(hide);
+
+    SystemTray::new().with_menu(tray_menu)
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -54,6 +54,10 @@
         "width": 720,
         "height": 405
       }
-    ]
+    ] ,
+    "systemTray": {
+      "iconPath": "icons/icon.ico",
+      "iconAsTemplate": true
+    }
   }
 }


### PR DESCRIPTION
- use "icons/icon.ico" as system tray
- right click the tray icon to show item menu
	- "hide" to make the program run in the background without window showing
	- "quit" to quit the program
- double click the tray icon to reshow the window

On branch main
Changes to be committed:
	modified:   Cargo.lock
	modified:   Cargo.toml            [add systemTray]
	modified:   src/main.rs		[add `system_tray` and `on_system_tray_event` to the app]
	new file:   src/sys_tray.rs          [a modulo for building SystemTray]
	modified:   tauri.conf.json	[add systemTray and set icon path]